### PR TITLE
allows for a arbitrary piece of text to be added to every search

### DIFF
--- a/leaflet-search.js
+++ b/leaflet-search.js
@@ -47,6 +47,7 @@ L.Control.Search = L.Control.extend({
 		textCancel: 'Cancel',		//title in cancel button
 		textErr: 'Location not found',	//error message
 		position: 'topleft',
+		searchAppend: null //allows for assisting in search params.
 		//TODO add option collapsed, like control.layers
 	},
 	
@@ -360,6 +361,9 @@ L.Control.Search = L.Control.extend({
 		L.Control.Search.callJsonp = function(data) {	//jsonp callback
 			var fdata = that._filterJSON.apply(that,[data]);//_filterJSON defined in inizialize...
 			callAfter(fdata);
+		}
+		if (this.options.searchAppend) {
+			text = text + ' ' + this.options.searchAppend;
 		}
 		var script = L.DomUtil.create('script','search-jsonp', document.getElementsByTagName('body')[0] ),			
 			url = L.Util.template(this.options.url+'&'+this.options.jsonpParam+'=L.Control.Search.callJsonp', {s: text}); //parsing url


### PR DESCRIPTION
Typing out full addresses into the geosearcher can get tiresome if you are consistently working in the same general area - a city for example.

This option allows you to append a string to every query by default so people can get quick results without having to type in street address + city + country.
