### PR TITLE
Bug fix

### DIFF
--- a/leaflet-search.js
+++ b/leaflet-search.js
@@ -84,7 +84,7 @@ L.Control.Search = L.Control.extend({
 
 	onRemove: function(map) {
 		this._recordsCache = {};
-		this._map.off({
+		map.off({
 				'layeradd': this._onLayerAddRemove,
 				'layerremove': this._onLayerAddRemove
 			}, this);


### PR DESCRIPTION
If you try to remove leaflet-search from map it will cause of null pointer exception inside onRemove function. This._map is null so it is not right way to call this._map.off especially you have _map_ as function parameter.
