### PR TITLE
Fix autoCollapse when set to false

### DIFF
--- a/leaflet-search.js
+++ b/leaflet-search.js
@@ -167,6 +167,7 @@ L.Control.Search = L.Control.extend({
 	},
 	
 	collapseDelayed: function() {	//collapse after delay, used on_input blur
+		if (!this.options.autoCollapse) return this;
 		var that = this;
 		clearTimeout(this.timerCollapse);
 		this.timerCollapse = setTimeout(function() {


### PR DESCRIPTION
Even with autoCollapse set to false the search results collapsed on autoCollapseTime. This fixes the issue and allows the results to stay until map movement or manual selection/cancel made.
