### PR TITLE
replace private variables by public methods

### DIFF
--- a/examples/google-geocoding.html
+++ b/examples/google-geocoding.html
@@ -53,7 +53,7 @@ Google Geocoding API <br />
 		{
 			key = rawjson[i].formatted_address;
 			
-			loc = L.latLng( rawjson[i].geometry.location.mb, rawjson[i].geometry.location.nb );
+			loc = L.latLng( rawjson[i].geometry.location.lat(), rawjson[i].geometry.location.lng() );
 			
 			json[ key ]= loc;	//key,value format
 		}


### PR DESCRIPTION
Hello.
There are private variables in your Google Geocoding example. They should be replaced by methods. Variables always have different names (compiler gives them names).
