### PR TITLE
Reference event listener instead of calling it

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -1,4 +1,3 @@
-
 (function() {
 
 L.Control.Search = L.Control.extend({
@@ -75,7 +74,7 @@ L.Control.Search = L.Control.extend({
 		 map.on({
 		// 		'layeradd': this._onLayerAddRemove,
 		// 		'layerremove': this._onLayerAddRemove
-		     'resize':this._handleAutoresize()
+		     'resize': this._handleAutoresize
 		 	}, this);
 		return this._container;
 	},


### PR DESCRIPTION
This was causing Leaflet to throw an error when the map was resized, as it was trying to call `undefined`.
