### PR TITLE
Circle markers patch

### DIFF
--- a/dist/leaflet-search.src.js
+++ b/dist/leaflet-search.src.js
@@ -486,7 +486,7 @@ L.Control.Search = L.Control.extend({
 
 			if(layer instanceof SearchMarker) return;
 
-			if(layer instanceof L.Marker)
+			if(layer instanceof L.Marker || L.CircleMarker)
 			{
 				if(that._getPath(layer.options,propName))
 				{

--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -470,7 +470,7 @@ L.Control.Search = L.Control.extend({
 
 			if(layer instanceof SearchMarker) return;
 
-			if(layer instanceof L.Marker)
+			if(layer instanceof L.Marker || L.CircleMarker)
 			{
 				if(that._getPath(layer.options,propName))
 				{


### PR DESCRIPTION
leaflet-search did not support CircleMarkers markers since they do not extend L.Marker but L.Circle.