### PR TITLE
Hides search tips when the cancel button is pressed

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -176,6 +176,7 @@ L.Control.Search = L.Control.extend({
 		this._input.size = this._inputMinSize;
 		this._input.focus();
 		this._cancel.style.display = 'none';
+		this._hideTooltip();
 		return this;
 	},
 	


### PR DESCRIPTION
Hi, this pull request just hides all of the search suggestions when a user presses the cancel/clear button to start a new search.