### PR TITLE
Added search for all layers in LayerGroup

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -504,6 +504,17 @@ L.Control.Search = L.Control.extend({
 				else
 					throw new Error("propertyName '"+propName+"' not found in marker");
 			}
+            else if(layer instanceof L.LayerGroup) // In LayerGroup search
+            {
+                // Add parsing L.LayerGroup
+                //TODO: Optimize
+                layer.eachLayer(function(lGroup) {
+                    loc = lGroup.getLatLng();
+                    loc.layer = lGroup;
+                    retRecords[ lGroup.feature.properties[propName] ] = loc;
+                })
+
+            }
 			else if(layer.hasOwnProperty('feature'))//GeoJSON layer
 			{
 				if(layer.feature.properties.hasOwnProperty(propName))


### PR DESCRIPTION
Hi.
Add search for LayerGroup

```js
map = L.map(...);

// Get GeoJSON data
caffe = new L.GeoJSON.AJAX('/caffe.json', {...});
restaurant = new L.GeoJSON.AJAX(('/restaurant.json', {...});

// Add LayerGroup
city = new L.LayerGroup();
city.addLayer(caffe);
city.addLayer(restaurant);

// Add search control
map.addControl( new L.Control.Search({
       layer: city,
       propertyName:'title',
    }) );

```
:cookie: 