### PR TITLE
wasn't properly handling toggle when toggle === false

### DIFF
--- a/dist/leaflet-search.src.js
+++ b/dist/leaflet-search.src.js
@@ -202,7 +202,7 @@ L.Control.Search = L.Control.extend({
 	},
 	
 	expand: function(toggle) {
-		toggle = toggle || true;
+		if(typeof toggle === 'undefined' ) { toggle = true };
 		this._input.style.display = 'block';
 		L.DomUtil.addClass(this._container, 'search-exp');
 		if ( toggle !== false ) {


### PR DESCRIPTION
The old version was setting toggle to true, when it should have remained false.  On android devices, this meant that the focus was be set to the input field, and the soft keyboard would popup on 'dragstart' since it is triggered by focus and blur.  

On my maps, this meant that whenever the search feature was visible, if i tried to drag the map, the keyboard would popup for a second before the focus switched back to the map, creating a buggy behavior.