### PR TITLE
Only add search button when search is not expanded

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -84,7 +84,9 @@ L.Control.Search = L.Control.extend({
 		this._input = this._createInput(this.options.textPlaceholder, 'search-input');
 		this._tooltip = this._createTooltip('search-tooltip');
 		this._cancel = this._createCancel(this.options.textCancel, 'search-cancel');
-		this._button = this._createButton(this.options.textPlaceholder, 'search-button');
+		if (this.options.collapsed) {
+			this._button = this._createButton(this.options.textPlaceholder, 'search-button');
+		}
 		this._alert = this._createAlert('search-alert');
 
 		if(this.options.collapsed===false)


### PR DESCRIPTION
The 'search' button which expands/shrinks the search option should only be added if the search option is not expanded.