### PR TITLE
Wrapping the throw new Errors in try catch blocks.

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -488,33 +488,40 @@ L.Control.Search = L.Control.extend({
 
 			if(layer instanceof L.Marker || layer instanceof L.CircleMarker)
 			{
-				if(that._getPath(layer.options,propName))
-				{
-					loc = layer.getLatLng();
-					loc.layer = layer;
-					retRecords[ that._getPath(layer.options,propName) ] = loc;			
+				try {
+					if(that._getPath(layer.options,propName))
+					{
+						loc = layer.getLatLng();
+						loc.layer = layer;
+						retRecords[ that._getPath(layer.options,propName) ] = loc;			
+						
+					}
+					else if(that._getPath(layer.feature.properties,propName)){
+	
+						loc = layer.getLatLng();
+						loc.layer = layer;
+						retRecords[ that._getPath(layer.feature.properties,propName) ] = loc;
+						
+					}
+					else
+						throw new Error("propertyName '"+propName+"' not found in marker");
 					
 				}
-				else if(that._getPath(layer.feature.properties,propName)){
-
-					loc = layer.getLatLng();
-					loc.layer = layer;
-					retRecords[ that._getPath(layer.feature.properties,propName) ] = loc;
-					
-				}
-				else
-					throw new Error("propertyName '"+propName+"' not found in marker");
+				catch(err){}
 			}
             else if(layer.hasOwnProperty('feature'))//GeoJSON
 			{
-				if(layer.feature.properties.hasOwnProperty(propName))
-				{
-					loc = layer.getBounds().getCenter();
-					loc.layer = layer;			
-					retRecords[ layer.feature.properties[propName] ] = loc;
+				try {
+					if(layer.feature.properties.hasOwnProperty(propName))
+					{
+						loc = layer.getBounds().getCenter();
+						loc.layer = layer;			
+						retRecords[ layer.feature.properties[propName] ] = loc;
+					}
+					else
+						throw new Error("propertyName '"+propName+"' not found in feature");
 				}
-				else
-					throw new Error("propertyName '"+propName+"' not found in feature");
+				catch(err){}
 			}
 			else if(layer instanceof L.LayerGroup)
             {

--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -507,7 +507,9 @@ L.Control.Search = L.Control.extend({
 						throw new Error("propertyName '"+propName+"' not found in marker");
 					
 				}
-				catch(err){}
+				catch(err){
+					if (console) {console.warn(err);}
+				}
 			}
             else if(layer.hasOwnProperty('feature'))//GeoJSON
 			{
@@ -521,7 +523,9 @@ L.Control.Search = L.Control.extend({
 					else
 						throw new Error("propertyName '"+propName+"' not found in feature");
 				}
-				catch(err){}
+				catch(err){
+					if (console) {console.warn(err);}
+				}
 			}
 			else if(layer instanceof L.LayerGroup)
             {


### PR DESCRIPTION
I noticed that the _getPath function returns undefined when the features property value is an empty string because it requires it to have a length > 0 to return a value. This means that when checking a list of layers if some of them have an empty string in the value of the field you are checking the code will raise an exception which causes the block of code to stop executing, with none of the matching records that were found getting returned. 
By wrapping both error blocks inside of try catch functions, the code can still throw errors for each layer, but now it will skip the layers which don't match, and still return a results list. 