### PR TITLE
Allowing GeoJSON Point records to be fully searched

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -486,7 +486,7 @@ L.Control.Search = L.Control.extend({
 			loc;
 		
 		this._layer.eachLayer(function(layer) {
-			var path;
+			var path = undefined;
 			
 			try {
 				if(layer instanceof L.Control.Search.Marker) return;

--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -512,7 +512,12 @@ L.Control.Search = L.Control.extend({
 				{
 					if(layer.feature.properties.hasOwnProperty(propName))
 					{
-						loc = layer.getBounds().getCenter();
+						if ( typeof layer.getBounds  == 'function' ) {
+							loc = layer.getBounds().getCenter();	
+						} else {
+							loc = layer.getLatLng();
+						}
+						
 						loc.layer = layer;			
 						path = layer.feature.properties[propName];
 					}

--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -486,6 +486,7 @@ L.Control.Search = L.Control.extend({
 			loc;
 		
 		this._layer.eachLayer(function(layer) {
+			var path;
 
 			if(layer instanceof L.Control.Search.Marker) return;
 
@@ -496,14 +497,14 @@ L.Control.Search = L.Control.extend({
 					{
 						loc = layer.getLatLng();
 						loc.layer = layer;
-						retRecords[ that._getPath(layer.options,propName) ] = loc;			
+						path = that._getPath(layer.options,propName);			
 						
 					}
 					else if(that._getPath(layer.feature.properties,propName)){
 	
 						loc = layer.getLatLng();
 						loc.layer = layer;
-						retRecords[ that._getPath(layer.feature.properties,propName) ] = loc;
+						path = that._getPath(layer.feature.properties,propName);
 						
 					}
 					else
@@ -521,7 +522,7 @@ L.Control.Search = L.Control.extend({
 					{
 						loc = layer.getBounds().getCenter();
 						loc.layer = layer;			
-						retRecords[ layer.feature.properties[propName] ] = loc;
+						path = layer.feature.properties[propName];
 					}
 					else
 						throw new Error("propertyName '"+propName+"' not found in feature");
@@ -531,14 +532,18 @@ L.Control.Search = L.Control.extend({
 				}
 			}
 			else if(layer instanceof L.LayerGroup)
-            {
-                //TODO: Optimize
-                layer.eachLayer(function(m) {
-                    loc = m.getLatLng();
-                    loc.layer = m;
-                    retRecords[ m.feature.properties[propName] ] = loc;
-                });
-            }
+			{
+				//TODO: Optimize
+				layer.eachLayer(function(m) {
+				    loc = m.getLatLng();
+				    loc.layer = m;
+				    path = m.feature.properties[propName];
+				});
+			}
+			
+			if ( loc && path ) {
+				retRecords[path] = loc;
+			}
 			
 		},this);
 		

--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -487,12 +487,12 @@ L.Control.Search = L.Control.extend({
 		
 		this._layer.eachLayer(function(layer) {
 			var path;
-
-			if(layer instanceof L.Control.Search.Marker) return;
-
-			if(layer instanceof L.Marker || layer instanceof L.CircleMarker)
-			{
-				try {
+			
+			try {
+				if(layer instanceof L.Control.Search.Marker) return;
+	
+				if(layer instanceof L.Marker || layer instanceof L.CircleMarker)
+				{
 					if(that._getPath(layer.options,propName))
 					{
 						loc = layer.getLatLng();
@@ -507,42 +507,33 @@ L.Control.Search = L.Control.extend({
 						path = that._getPath(layer.feature.properties,propName);
 						
 					}
-					else
-						throw new Error("propertyName '"+propName+"' not found in marker");
-					
 				}
-				catch(err){
-					if (console) {console.warn(err);}
-				}
-			}
-            		if(layer.hasOwnProperty('feature'))//GeoJSON
-			{
-				try {
+	            		if(layer.hasOwnProperty('feature'))//GeoJSON
+				{
 					if(layer.feature.properties.hasOwnProperty(propName))
 					{
 						loc = layer.getBounds().getCenter();
 						loc.layer = layer;			
 						path = layer.feature.properties[propName];
 					}
-					else
-						throw new Error("propertyName '"+propName+"' not found in feature");
 				}
-				catch(err){
-					if (console) {console.warn(err);}
+				else if(layer instanceof L.LayerGroup)
+				{
+					//TODO: Optimize
+					layer.eachLayer(function(m) {
+					    loc = m.getLatLng();
+					    loc.layer = m;
+					    path = m.feature.properties[propName];
+					});
 				}
+				
+				if ( loc && path ) {
+					retRecords[path] = loc;
+				} else
+					throw new Error("propertyName '"+ propName+"' not found in layer");
 			}
-			else if(layer instanceof L.LayerGroup)
-			{
-				//TODO: Optimize
-				layer.eachLayer(function(m) {
-				    loc = m.getLatLng();
-				    loc.layer = m;
-				    path = m.feature.properties[propName];
-				});
-			}
-			
-			if ( loc && path ) {
-				retRecords[path] = loc;
+			catch(err) {
+				if(console) { console.warn(err); }
 			}
 			
 		},this);

--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -514,7 +514,7 @@ L.Control.Search = L.Control.extend({
 					if (console) {console.warn(err);}
 				}
 			}
-            else if(layer.hasOwnProperty('feature'))//GeoJSON
+            		if(layer.hasOwnProperty('feature'))//GeoJSON
 			{
 				try {
 					if(layer.feature.properties.hasOwnProperty(propName))


### PR DESCRIPTION
GeoJSON datasets are composed of Point, MultiPoint, LineString, MultiLineString, Polygons, MultiPolygons, and GeometryCollections.  When a dataset contains Point or MultiPoint data, the sub-layer in the geoJSON layer is an instance of L.Marker( see: [L.GeoJSON](https://github.com/Leaflet/Leaflet/blob/1b405dc10ef41687b7810f5c6bbf4ac4cf547397/src/layer/GeoJSON.js#L158-L167)  ) This means that it returns true for the first part of the `if` statement, and skips the second part.
By removing the `else` we are allowing the function to search both the `L.Marker` options as well as the `layer.feature` which L.Markers have when they are part of a geoJSON layer.