### PR TITLE
Fix : Pasted value automatically launch search.

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -300,7 +300,7 @@ L.Control.Search = L.Control.extend({
 
 		L.DomEvent
 			.disableClickPropagation(input)
-			.on(input, 'keydown', this._handleKeypress, this)
+			.on(input, 'keyup', this._handleKeypress, this)
 			.on(input, 'blur', this.collapseDelayed, this)
 			.on(input, 'focus', this.collapseDelayedStop, this);
 		


### PR DESCRIPTION
Hi!

There is an issue in master branch. If you **paste a value** into the searchbox, the **research wasn't launched** automatically. 

I reproduce the issue there : http://labs.easyblog.it/maps/leaflet-search/examples/google-geocoding.html

I had to catch the _paste_ key. Instead of listen **_keydown_**, I modify the source to listen **_keyup_** then it catches the _paste_ key.

I hope that's all right. 
Corentin.
