### PR TITLE
If both layer and url is specified in config, allow to search both.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,7 @@ grunt.initConfig({
 	},	
 	jshint: {
 		options: {
+      ignores: ['src/polyfills.js'],
 			globals: {
 				'no-console': true,
 				module: true
@@ -52,7 +53,7 @@ grunt.initConfig({
 			'-W033': true,
 			'-W044': true	//ignore regexp
 		},
-		files: ['src/*.js']
+    files: ['src/*.js']
 	},
 	concat: {
 		//TODO cut out SearchMarker
@@ -61,7 +62,7 @@ grunt.initConfig({
 		},
 		dist: {
 			files: {
-				'dist/leaflet-search.src.js': ['src/leaflet-search.js'],			
+				'dist/leaflet-search.src.js': ['src/polyfills.js', 'src/leaflet-search.js'],			
 				'dist/leaflet-search.src.css': ['src/leaflet-search.css'],
 				'dist/leaflet-search.mobile.src.css': ['src/leaflet-search.mobile.css']
 			}

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,29 @@
+if (typeof Object.assign != 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, "assign", {
+    value: function assign(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}


### PR DESCRIPTION
In our project we want to search both layers and from external source (AJAX). This PR allows that.

I work on the same project as the author of this PR:
https://github.com/stefanocudini/leaflet-search/issues/183
However that PR was uneccesarily complicated, and also had become stale from the current branch.

If `options.layer`is specified, it will first search that one.
If `options.url` is specified, it will append AJAX response to whatever results from layer.