### PR TITLE
Added link for Craft Ottawa to use cases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,4 @@ This list is intended to be of utility for all developers who are looking web ma
 * [EDSM - Galactic Map](https://www.edsm.net/en/galactic-mapping)
 * [The area of effect of the "MOAB" bomb in Afghanistan](https://www.dhkconsulting.com/moab/moab.html)
 * [Ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet)
+* [Craft Ottawa](https://craftottawa.ca)


### PR DESCRIPTION
I added leaflet-search to the code in March 2020. leaflet-search was exactly what I was looking for while I was building the map component of Craft Ottawa. The site went live in June 2020 and leaflet-search perform flawlessly.