### PR TITLE
Fix the records cache not filling properly when the layer is set dynamically

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -752,7 +752,7 @@ L.Control.Search = L.Control.extend({
 
 		L.DomUtil.addClass(this._container, 'search-load');	
 
-		if(this.options.layer)
+		if(this._layer)
 		{
 			//TODO _recordsFromLayer must return array of objects, formatted from _formatData
 			this._recordsCache = this._recordsFromLayer();


### PR DESCRIPTION
The `_fillRecordsCache` function uses the layer property passed in as an option to determine whether it should fill the records cache using a layer. If the layer was not specified at the time of creation and instead specified dynamically via `setLayer`, this does not work because the layer property in options is not updated by `setLayer`.