### PR TITLE
feat: Added support for CSS @import

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "http://labs.easyblog.it/"
   },
   "main": "dist/leaflet-search.src.js",
+  "style": "dist/leaflet-search.src.css",
   "license": "MIT",
   "keywords": [
     "gis",


### PR DESCRIPTION
This line is required in package.json to import CSS as a package using `@import`.