### PR TITLE
fix: firefox `mousewheel` => `wheel`

### DIFF
--- a/src/leaflet-search.js
+++ b/src/leaflet-search.js
@@ -359,7 +359,7 @@ L.Control.Search = L.Control.extend({
 		L.DomEvent
 			.disableClickPropagation(tool)
 			.on(tool, 'blur', this.collapseDelayed, this)
-			.on(tool, 'mousewheel', function(e) {
+			.on(tool, 'wheel', function(e) {
 				self.collapseDelayedStop();
 				L.DomEvent.stopPropagation(e);//disable zoom map
 			}, this)


### PR DESCRIPTION
ignore `.npmrc` 

Tested in Chrome & Firefox [test here](https://leaflet-search.fumlersoft.dk/examples/simple.html) self-signed (by me) certificate.

https://github.com/trasherdk/leaflet-search/tree/fix/mousewheel
